### PR TITLE
Fix queue target in Dockerfile

### DIFF
--- a/config/queue.Dockerfile
+++ b/config/queue.Dockerfile
@@ -24,7 +24,7 @@ COPY services/silo-api ./services/silo-api
 WORKDIR /app/services/forge-queue
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/app/target \
-    cargo build --release && \
+    cargo build --release -p forge && \
     cp /app/target/release/queue /usr/local/bin/queue
 
 # Runtime stage

--- a/config/queue.Dockerfile
+++ b/config/queue.Dockerfile
@@ -25,7 +25,7 @@ WORKDIR /app/services/forge-queue
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/app/target \
     cargo build --release -p forge && \
-    cp /app/target/release/queue /usr/local/bin/queue
+    cp /app/target/release/forge /usr/local/bin/forge
 
 # Runtime stage
 FROM --platform=$TARGETPLATFORM debian:bullseye-slim
@@ -38,7 +38,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy the binary from builder
-COPY --from=builder /usr/local/bin/queue /usr/local/bin/queue
+COPY --from=builder /usr/local/bin/forge /usr/local/bin/forge
 
 # Set the entrypoint
 ENTRYPOINT ["/usr/local/bin/queue"]


### PR DESCRIPTION
Fixes what binary we were targeting in the Dockerfile. Also updates the build step to only build the queue package